### PR TITLE
Adds "skip_long_lines" configuration for files inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ _Note: All of the tail plugin defaults can also be set on a per-input basis, usi
 - Description: This sets the default for the maximum amount of data the tail plugin will buffer before forcing a flush. This limit is permissive, and may be exceeded by the value of `tail_input.buffer_chunk_sz - 1`.
 - Default: `tail_input.buffer_max_sz: 5M`
 
+#### tail_input.skip_long_lines
+- Description: When td-agent-bit encounters a log line that is larger than buffer_chunk_sz, it is not possible for it to ingest this line. Ordinarily, td-agent-bit will indefinitely halt processing on that file when this occurs. This setting directs td-agent-bit to instead skip the problematic line and carry on. This may result in data loss, so in certain situations where that is absolutely unacceptable setting this to Off and having rigorous monitoring to know when td-agent-bit has halted may be preferable.
+- Default: `tail_input.skip_long_lines: On`
+
 #### tail_input.state_db
 - Description: This sets the default path for the internal state databases that the tail plugin will create. One database will be created for each monitored file. The database helps td-agent-bit retain state in the event of a system failure, and also helps the agent track with logrotate more effectively.
 - Default: `tail_input.state_db: /var/log/.flb-buffer`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,5 +37,6 @@ tail_input:
   rotate_maxsize: 5M
   rotate_strategy: copytruncate
   rotate_allow_duplicates: true
+  skip_long_lines: On
 # rotate_owner: www
 # rotate_group: www

--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -38,6 +38,7 @@
     DB                  {{ item.state_db | default( tail_input.state_db + '/' + (( item.path | basename | splitext)[0] | replace('*', '_all_' ))  + '.state' )}}
     DB.Sync             {{ item.state_db_sync | default( tail_input.state_db_sync )}}
     Mem_Buf_Limit       {{ item.mem_max_sz | default( tail_input.mem_max_sz )}}
+    Skip_Long_Lines     {{ item.skip_long_lines | default( tail_input.skip_long_lines ) }}
 {% if item.exclude_path is defined or tail_input.exclude_path is defined %}
     Exclude_Path        {{ item.exclude_path | default(tail_input.exclude_path) }}
 {% endif %}


### PR DESCRIPTION
This PR adds the "skip_long_lines" configuration option.

When td-agent-bit encounters a log line that is larger than buffer_chunk_sz, it is not possible for it to ingest this line. Ordinarily, td-agent-bit will indefinitely halt processing on that file when this occurs. The `skip_long_lines` setting directs td-agent-bit to instead skip the problematic line and carry on.
