### PR TITLE
Enable compiling with HTTP server when needed

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -169,6 +169,7 @@
           - "-DFLB_BUFFERING=ON"
           - "-DFLB_WITHOUT_EXAMPLES=ON"
           - "-DFLB_TD=ON"
+          - "-DFLB_HTTP_SERVER={{ (flb_metrics_enable | bool) | ternary('ON', 'OFF') }}"
           - "-DFLB_IN_SYSTEMD={{ ansible_service_mgr | lower == 'systemd' | ternary('ON','OFF') }}"
           - "-DCMAKE_INSTALL_SYSCONFDIR={{ flb_sys_conf_dir }}"
           - "-DCMAKE_INSTALL_FULL_BINDIR={{ flb_build_install_prefix }}/bin"


### PR DESCRIPTION
Currently, if installed from source, you cannot enable the HTTP metrics server.

there is still and error: 
```
fatal: [payments-quantity-invalidator-3-west.npm.red]: FAILED! => {"changed": false, "msg": "AnsibleFilterError: The ipaddr filter requires python's netaddr be installed on the ansible controller"}
```

it solved with `sudo apt install --no-install-recommends python-netaddr` on the host, but I have not enough knowledge on how to automate it.